### PR TITLE
Add basic tests and pytest helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+
+# Virtual env
+venv/
+
+# Test logs or caches
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # SRIS
 Semantic Reasoning Intelligence System
+
+## Running tests
+
+Use the provided `pytest` script from the project root:
+
+```bash
+./pytest
+```
+
+Additional arguments are passed directly to `pytest`.

--- a/pytest
+++ b/pytest
@@ -1,0 +1,2 @@
+#!/bin/bash
+python -m pytest "$@"

--- a/tests/test_semantic_memory_index.py
+++ b/tests/test_semantic_memory_index.py
@@ -1,0 +1,83 @@
+import os
+import sys
+import types
+from unittest.mock import patch
+import pytest
+
+def setup_dummy_llama(monkeypatch):
+    core = types.ModuleType("llama_index.core")
+    class DummyDocument:
+        def __init__(self, text, metadata=None):
+            self.text = text
+            self.metadata = metadata or {}
+    class DummyStorageContext:
+        @classmethod
+        def from_defaults(cls, persist_dir=None):
+            return cls()
+        def persist(self, persist_dir):
+            os.makedirs(persist_dir, exist_ok=True)
+            open(os.path.join(persist_dir, "docstore.json"), "w").write("dummy")
+    class DummyIndex:
+        def __init__(self, docs=None):
+            self.docs = list(docs or [])
+            self.storage_context = DummyStorageContext()
+        @classmethod
+        def from_documents(cls, docs):
+            return cls(docs)
+    def load_index_from_storage(storage_context):
+        return DummyIndex()
+    class DummySettings:
+        pass
+    core.Document = DummyDocument
+    core.VectorStoreIndex = DummyIndex
+    core.StorageContext = DummyStorageContext
+    core.load_index_from_storage = load_index_from_storage
+    core.Settings = DummySettings
+
+    emb = types.ModuleType("llama_index.embeddings.huggingface")
+    class HuggingFaceEmbedding:
+        def __init__(self, model_name=None, device=None):
+            pass
+    emb.HuggingFaceEmbedding = HuggingFaceEmbedding
+
+    llms = types.ModuleType("llama_index.llms.ollama")
+    class Ollama:
+        def __init__(self, model=None, base_url=None):
+            pass
+    llms.Ollama = Ollama
+
+    monkeypatch.setitem(sys.modules, "llama_index.core", core)
+    monkeypatch.setitem(sys.modules, "llama_index.embeddings.huggingface", emb)
+    monkeypatch.setitem(sys.modules, "llama_index.llms.ollama", llms)
+
+    return core
+
+
+def test_get_or_build_semantic_index_build(monkeypatch, tmp_path):
+    core = setup_dummy_llama(monkeypatch)
+    import importlib
+    smi = importlib.import_module("semantic_memory_index")
+    monkeypatch.setattr(smi, "INDEX_STORAGE_DIR", str(tmp_path))
+    Document = core.Document
+
+    monkeypatch.setattr(smi, "_load_all_reasoning_chains_as_documents", lambda: [Document("a")])
+    monkeypatch.setattr(smi, "_load_wikidata_concepts_as_documents", lambda qids: [])
+    monkeypatch.setattr(smi, "_load_core_sris_knowledge_as_documents", lambda: [])
+
+    idx = smi.get_or_build_semantic_index(rebuild=False)
+    assert idx is not None
+    assert os.path.exists(tmp_path / "docstore.json")
+
+
+def test_get_or_build_semantic_index_load(monkeypatch, tmp_path):
+    core = setup_dummy_llama(monkeypatch)
+    import importlib
+    smi = importlib.import_module("semantic_memory_index")
+    monkeypatch.setattr(smi, "INDEX_STORAGE_DIR", str(tmp_path))
+    os.makedirs(tmp_path, exist_ok=True)
+    (tmp_path / "docstore.json").write_text("dummy")
+
+    monkeypatch.setattr(smi, "load_index_from_storage", lambda sc: core.VectorStoreIndex())
+
+    idx = smi.get_or_build_semantic_index(rebuild=False)
+    assert isinstance(idx, core.VectorStoreIndex)

--- a/tests/test_wikidata_client.py
+++ b/tests/test_wikidata_client.py
@@ -1,0 +1,58 @@
+import builtins
+from unittest.mock import patch, Mock
+import pytest
+
+from wikidata_client import query_wikidata, format_wikidata_entity_data
+
+
+def test_query_wikidata_parses_response():
+    fake_json = {
+        "results": {
+            "bindings": [
+                {
+                    "item": {"value": "Q1"},
+                    "itemLabel": {"value": "Label"},
+                    "lang": {"value": "en"}
+                }
+            ]
+        }
+    }
+    mock_resp = Mock()
+    mock_resp.json.return_value = fake_json
+    mock_resp.raise_for_status = Mock()
+
+    with patch('requests.get', return_value=mock_resp) as mock_get:
+        res = query_wikidata("SELECT * WHERE {}")
+        mock_get.assert_called_once()
+
+    assert res == [{"item": "Q1", "itemLabel": "Label", "lang": "en"}]
+
+
+def test_format_wikidata_entity_data():
+    sample_results = [
+        {
+            "lang": "ru",
+            "itemLabel": "ИИ",
+            "itemDescription": "описание",
+            "itemAltLabel": "искусственный интеллект",
+            "instanceOfLabel": "концепция",
+            "instanceOf": "Q1234",
+            "subclassOfLabel": "технология",
+            "subclassOf": "Q5678",
+        },
+        {
+            "lang": "en",
+            "itemLabel": "AI",
+            "itemDescription": "description",
+            "itemAltLabel": "artificial intelligence",
+            "instanceOfLabel": "concept",
+            "instanceOf": "Q1234",
+            "subclassOfLabel": "technology",
+            "subclassOf": "Q5678",
+        },
+    ]
+    formatted = format_wikidata_entity_data("Q1", sample_results)
+
+    assert "Концепция (RU): ИИ (QID: Q1)" in formatted["ru"]
+    assert "Описание: описание" in formatted["ru"]
+    assert "Концепция (EN): AI (QID: Q1)" in formatted["en"]


### PR DESCRIPTION
## Summary
- add unit tests for wikidata client helpers
- add tests for semantic index builder using dummy llama-index modules
- include a pytest helper script and update README
- ignore test caches

## Testing
- `./pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861032494ec8321a6172626de2c36d6