### PR TITLE
Add direct server run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # SRIS
 Semantic Reasoning Intelligence System
+
+## Running the API server
+
+You can run the FastAPI server using Uvicorn:
+
+```bash
+uvicorn sris_server:app --host 0.0.0.0 --port 8000
+```
+
+Alternatively run the module directly:
+
+```bash
+python sris_server.py
+```

--- a/sris_server.py
+++ b/sris_server.py
@@ -102,3 +102,7 @@ async def process_user_query(request: QueryRequest):
 @app.get("/")
 def read_root():
     return {"SRIS_Status": "Alive", "Core_Version": "1.0-Prometheus", "Docs": "/docs"}
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("sris_server:app", host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add `if __name__ == "__main__"` block to run the FastAPI app directly
- document two ways to start the server in README

## Testing
- `python -m py_compile sris_server.py`

------
https://chatgpt.com/codex/tasks/task_e_687b9566b5e083218e323778e5c35f9d