### PR TITLE
Add unit tests for utils and instructions for pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # SRIS
 Semantic Reasoning Intelligence System
+
+## Running tests
+
+This project uses [pytest](https://docs.pytest.org/) for its test suite. After
+installing the dependencies (e.g. `pip install -r requirements.txt` if
+available), run the tests with:
+
+```bash
+pytest
+```
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import _extract_json_from_response
+
+
+def test_extract_json_from_code_block():
+    text = "some prefix ```json {\"a\": 1} ``` some suffix"
+    assert _extract_json_from_response(text) == '{"a": 1}'
+
+
+def test_extract_json_simple():
+    text = "random text {\"b\": 2} trailing"
+    assert _extract_json_from_response(text) == '{"b": 2}'
+
+
+def test_extract_json_nested():
+    text = "start {\"a\": {\"b\": 3}} end"
+    assert _extract_json_from_response(text) == '{"a": {"b": 3}}'
+
+
+def test_extract_json_missing_braces():
+    text = "no braces here"
+    assert _extract_json_from_response(text) is None
+
+
+def test_extract_json_unclosed():
+    text = "start {\"a\": 1"
+    assert _extract_json_from_response(text) is None
+


### PR DESCRIPTION
## Summary
- add `tests/` directory with tests for `_extract_json_from_response`
- document how to run the test suite with `pytest`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b956528f0832190f02133fb828b7e