### PR TITLE
Add setup docs and requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # SRIS
+
 Semantic Reasoning Intelligence System
+
+## Системные требования
+- Python 3.10+
+- Git
+- CUDA Toolkit и cuDNN (для работы через GPU)
+
+## Подготовка окружения
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -r requirements.txt
+```
+
+## Модели
+Для `llama-cpp-python` требуется заранее скачать GGUF-модель (например, `mistral-7b-instruct-v0.2.Q4_K_M.gguf`) и поместить её в папку `models` в корне проекта. Путь к файлу настраивается в `mistral_core.py`.
+
+## Запуск API
+```bash
+uvicorn sris_server:app --reload
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn[standard]
+pydantic
+llama-cpp-python
+transformers
+torch
+llama-index
+requests


### PR DESCRIPTION
## Summary
- document system requirements, virtual env creation, downloading GGUF model and starting the API server
- add package requirements list

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6861032292a08321a5f05ab2a58c6d0d