### PR TITLE
Switch prints to logging and unify configuration

### DIFF
--- a/adaptive_logic.py
+++ b/adaptive_logic.py
@@ -1,5 +1,12 @@
 # adaptive_logic.py
 
+import logging
+
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
+
 # Conceptual Imports: These would be calls to SRIS's core semantic processing.
 # In a real system, this might involve semantic embeddings, knowledge graphs, etc.
 # from semantic_core_utilities import get_semantic_similarity, get_concept_category, filter_by_semantic_relevance
@@ -90,24 +97,24 @@ if __name__ == "__main__":
         "Wait for further instructions."
     ]
 
-    print("--- Analytical Mode (deep_scan) ---")
-    print(f"Original: {sample_hypotheses}")
-    print(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'analytical_deep_scan')}\n")
+    logger.info("--- Analytical Mode (deep_scan) ---")
+    logger.info(f"Original: {sample_hypotheses}")
+    logger.info(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'analytical_deep_scan')}\n")
 
-    print("--- Threat Response Mode (urgent) ---")
-    print(f"Original: {sample_hypotheses}")
-    print(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'threat_response_urgent')}\n")
+    logger.info("--- Threat Response Mode (urgent) ---")
+    logger.info(f"Original: {sample_hypotheses}")
+    logger.info(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'threat_response_urgent')}\n")
 
-    print("--- Creative Mode (dream_cycle) ---")
-    print(f"Original: {sample_hypotheses}")
-    print(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'creative_dream_cycle')}\n")
+    logger.info("--- Creative Mode (dream_cycle) ---")
+    logger.info(f"Original: {sample_hypotheses}")
+    logger.info(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'creative_dream_cycle')}\n")
 
-    print("--- Default Mode with high threat perception ---")
+    logger.info("--- Default Mode with high threat perception ---")
     perception_with_threat = {'threat_level': 0.8, 'summary': 'Hostile entity detected'}
-    print(f"Original: {sample_hypotheses}")
-    print(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'default_mode', perception_with_threat)}\n")
+    logger.info(f"Original: {sample_hypotheses}")
+    logger.info(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'default_mode', perception_with_threat)}\n")
 
-    print("--- Exploratory Mode with high novelty perception ---")
+    logger.info("--- Exploratory Mode with high novelty perception ---")
     perception_with_novelty = {'novelty': 0.9, 'summary': 'Unidentified anomaly detected'}
-    print(f"Original: {sample_hypotheses}")
-    print(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'exploratory_discovery', perception_with_novelty)}\n")
+    logger.info(f"Original: {sample_hypotheses}")
+    logger.info(f"Adjusted: {adjust_hypotheses(sample_hypotheses, 'exploratory_discovery', perception_with_novelty)}\n")

--- a/dream_cycle.py
+++ b/dream_cycle.py
@@ -172,15 +172,15 @@ if __name__ == "__main__":
     sys.modules['cause_effect'] = MockCauseEffect()
 
 
-    print("--- Running Dream Cycle with context ---")
+    logger.info("--- Running Dream Cycle with context ---")
     dream_log = run_dream_cycle(
         current_sDNA=mock_sDNA,
         current_goals=mock_goals,
         recent_memory_patterns=mock_recent_memory
     )
     for entry in dream_log:
-        print(f"[{entry['timestamp']}] Idea: '{entry['dream_seed_idea']}' -> Simulated Hypothesis: '{entry['simulated_hypothesis']}' (Score: {entry['score_simulated']}) | Affect: {entry['simulated_emotional_label']}")
+        logger.info(f"[{entry['timestamp']}] Idea: '{entry['dream_seed_idea']}' -> Simulated Hypothesis: '{entry['simulated_hypothesis']}' (Score: {entry['score_simulated']}) | Affect: {entry['simulated_emotional_label']}")
         if entry.get('simulated_zav2_violations'):
-            print(f"  Simulated ZAV2 Violations: {entry['simulated_zav2_violations']}")
+            logger.info(f"  Simulated ZAV2 Violations: {entry['simulated_zav2_violations']}")
         if entry.get('simulated_effects'):
-            print(f"  Simulated Effects: {entry['simulated_effects'][0]['concept']} (Valence: {entry['simulated_effects'][0]['valence_impact']})")
+            logger.info(f"  Simulated Effects: {entry['simulated_effects'][0]['concept']} (Valence: {entry['simulated_effects'][0]['valence_impact']})")

--- a/emotional_processor.py
+++ b/emotional_processor.py
@@ -1,5 +1,11 @@
 # emotional_processor.py
+import logging
 from typing import Dict, Any
+
+from logging_config import setup_logging
+
+setup_logging()
+logger = logging.getLogger(__name__)
 
 def evaluate_emotion(perception_struct: Dict[str, Any], chosen_hypothesis: str) -> Dict[str, Any]:
     """
@@ -18,9 +24,9 @@ def evaluate_emotion(perception_struct: Dict[str, Any], chosen_hypothesis: str) 
                  Valence: positive/negative (-1.0 to 1.0)
                  Arousal: intensity/energy (0.0 to 1.0)
     """
-    print(f"\n[EMOTIONAL PROCESSOR INPUT]")
-    print(f"Perception Sentiment: {perception_struct.get('sentiment', 'unknown')}")
-    print(f"Chosen Hypothesis: {chosen_hypothesis[:100]}...") # Print part for brevity
+    logger.info("\n[EMOTIONAL PROCESSOR INPUT]")
+    logger.info(f"Perception Sentiment: {perception_struct.get('sentiment', 'unknown')}")
+    logger.info(f"Chosen Hypothesis: {chosen_hypothesis[:100]}...")
 
     valence = 0.0  # Default to neutral
     arousal = 0.1  # Default to low arousal
@@ -70,7 +76,7 @@ def evaluate_emotion(perception_struct: Dict[str, Any], chosen_hypothesis: str) 
         "details": f"Based on sentiment: {perception_sentiment} and hypothesis content."
     }
 
-    print(f"Evaluated Emotion State: {emotion_state}")
+    logger.info(f"Evaluated Emotion State: {emotion_state}")
     return emotion_state
 
 # Example usage (can be uncommented for quick testing of this module)

--- a/goal_engine.py
+++ b/goal_engine.py
@@ -4,9 +4,10 @@ import uuid
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 
+from logging_config import setup_logging
+
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 def form_goal(
     perception_struct: Dict[str, Any], 

--- a/logging_config.py
+++ b/logging_config.py
@@ -1,0 +1,10 @@
+import logging
+
+LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+
+def setup_logging(level: int = logging.INFO) -> None:
+    """Configure root logging once."""
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format=LOG_FORMAT)

--- a/mistral_core.py
+++ b/mistral_core.py
@@ -2,6 +2,8 @@
 # Универсальный интерфейс для вызова LLM: через transformers или llama-cpp-python (gguf)
 import os
 import logging
+
+from logging_config import setup_logging
 import time # Для измерения времени
 
 # --- Конфигурация ---
@@ -28,9 +30,8 @@ HF_MODEL_NAME: str = "mistralai/Mistral-7B-Instruct-v0.2"
 # Это потребует `pip install bitsandbytes accelerate`
 
 # Настройка логирования
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- Инициализация модели ---
 llm_instance = None
@@ -147,12 +148,12 @@ if __name__ == '__main__':
 
         logger.info("\n--- Тест режима 'analyze' ---")
         response_analyze = query_mistral(test_prompt_analyze, mode="analyze", max_new_tokens=150)
-        print(f"Ответ 'analyze':\n{response_analyze}\n")
+        logger.info(f"Ответ 'analyze':\n{response_analyze}\n")
 
         logger.info("\n--- Тест режима 'generate' ---")
         response_generate = query_mistral(test_prompt_generate, mode="generate", max_new_tokens=200)
-        print(f"Ответ 'generate':\n{response_generate}\n")
+        logger.info(f"Ответ 'generate':\n{response_generate}\n")
 
         logger.info("\n--- Тест режима 'respond' ---")
         response_respond = query_mistral(test_prompt_respond, mode="respond", max_new_tokens=50)
-        print(f"Ответ 'respond':\n{response_respond}\n")
+        logger.info(f"Ответ 'respond':\n{response_respond}\n")

--- a/ml_nae_core.py
+++ b/ml_nae_core.py
@@ -1,5 +1,7 @@
 # ml_nae_core.py
 import logging
+
+from logging_config import setup_logging
 from typing import Dict, Any, List, Optional, TypedDict, Callable
 import math # Для sigmoid или других функций нормализации, если понадобятся
 
@@ -12,10 +14,8 @@ import math # Для sigmoid или других функций нормализ
 # from sris_constants import ZAV2_CRITICAL_VIOLATION_FLAG # Пример флага
 
 # --- Настройка логгера ---
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- 1. Спецификация интерфейсов и структур данных ---
 
@@ -527,16 +527,16 @@ Estimated Risk Level: low
     # === Test Run 1: Normal situation ===
     logger.info("\n--- ML-NAE Test 1: Нормальная ситуация (озадаченный пользователь) ---")
     action1 = ml_nae.decide(example_context_ru)
-    print(f"ML-NAE Решение 1: {action1}")
+    logger.info(f"ML-NAE Решение 1: {action1}")
 
     # === Test Run 2: Critical Threat ===
     logger.info("\n--- ML-NAE Test 2: Критическая угроза (ожидаем рефлекс) ---")
     action2 = ml_nae.decide(example_context_critical_threat)
-    print(f"ML-NAE Решение 2: {action2}")
+    logger.info(f"ML-NAE Решение 2: {action2}")
     
     # === Test Run 3: ZAV2 flag ===
     example_context_zav2_violation = example_context_ru.copy() # Копируем нормальный контекст
     example_context_zav2_violation["system_flags"] = {"zav2_violation_imminent": True}
     logger.info("\n--- ML-NAE Test 3: Флаг нарушения ZAV2 (ожидаем рефлекс) ---")
     action3 = ml_nae.decide(example_context_zav2_violation)
-    print(f"ML-NAE Решение 3: {action3}")
+    logger.info(f"ML-NAE Решение 3: {action3}")

--- a/semantic_memory_fs.py
+++ b/semantic_memory_fs.py
@@ -5,6 +5,8 @@ import json
 from datetime import datetime, timezone
 import uuid
 import logging
+
+from logging_config import setup_logging
 from typing import Dict, Any, Optional, Union
 
 # --- Configuration & Setup ---
@@ -17,12 +19,8 @@ except OSError as e:
     # Depending on the application's criticality, you might raise the exception
     # or have a fallback mechanism. For now, we'll just log.
 
-# Setup basic logging. In a larger application, logging would be configured globally.
-# Set a more informative format.
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
+# Setup basic logging if not already configured
+setup_logging()
 logger = logging.getLogger(__name__) # Use __name__ for logger hierarchy
 
 # --- Functions ---

--- a/semantic_memory_index.py
+++ b/semantic_memory_index.py
@@ -2,6 +2,8 @@
 import os
 import json
 import logging
+
+from logging_config import setup_logging
 from typing import List, Dict, Any, Optional, Set
 import uuid
 
@@ -63,9 +65,8 @@ CORE_SRIS_KNOWLEDGE = [
     }
 ]
 
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers: 
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 try:
     Settings.llm = Ollama(model=OLLAMA_LLM_MODEL_NAME, base_url=OLLAMA_LLM_BASE_URL)

--- a/sris_kernel.py
+++ b/sris_kernel.py
@@ -28,6 +28,8 @@ from typing import Dict, Any, Optional, List
 import json
 import random
 import logging
+
+from logging_config import setup_logging
 import time
 
 # ---- GUI Imports ----
@@ -58,9 +60,8 @@ except ImportError:
     sris_timeline = ReasoningTimeline(sris_timesense) # type: ignore
 
 # Настройка логирования
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
 # --- Константы и глобальные переменные SRIS ---
 DEFAULT_SDNA = {"adaptivity":0.7,"ethics_sensitivity":0.8,"thinking_style":"deductive","curiosity_level":0.6,"security_priority":0.4,"risk_aversion":0.5,"empathy_level":0.5,"novelty_seeking":0.6,"risk_taking":0.5,"proactiveness":0.5,"efficiency_preference":0.5,"ethical_risk_aversion":0.5,"assertiveness_level":0.5,"transparency_level":0.5}
@@ -409,10 +410,10 @@ class SRISChatApp:
         thread.start()
 
 if __name__ == "__main__":
-    print("--- SRIS Kernel с GUI ---")
-    print("--- Логи работы ядра будут выводиться в терминале. ---")
-    print("--- Закройте окно GUI для завершения программы. ---")
+    logger.info("--- SRIS Kernel с GUI ---")
+    logger.info("--- Логи работы ядра будут выводиться в терминале. ---")
+    logger.info("--- Закройте окно GUI для завершения программы. ---")
     main_window = tk.Tk()
     app = SRISChatApp(main_window)
     main_window.mainloop()
-    print("\n--- Программа SRIS завершена ---")
+    logger.info("\n--- Программа SRIS завершена ---")

--- a/sris_server.py
+++ b/sris_server.py
@@ -1,6 +1,8 @@
 # sris_server.py
 import logging
 import time
+
+from logging_config import setup_logging
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
@@ -17,14 +19,13 @@ try:
     )
     sris_components_loaded = True
 except ImportError as e:
-    logging.basicConfig(level=logging.ERROR)
+    setup_logging(logging.ERROR)
     logging.error(f"Критическая ошибка: не удалось импортировать компоненты SRIS. {e}")
     sris_components_loaded = False
 
 # --- Настройка логирования ---
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- Модели данных для API ---
 class QueryRequest(BaseModel):

--- a/wikidata_client.py
+++ b/wikidata_client.py
@@ -2,13 +2,13 @@
 import requests
 import json
 import logging
+
+from logging_config import setup_logging
 from typing import List, Dict, Optional, Any # Добавил Any
 
 # Настройка логгера
+setup_logging()
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 WIKIDATA_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
 WIKIDATA_API_ENDPOINT = "https://www.wikidata.org/w/api.php" # Эндпоинт для wbsearchentities
@@ -143,7 +143,7 @@ def format_wikidata_entity_data(qid: str, sparql_results: List[Dict[str, str]]) 
 
 # ===== БЛОК ДЛЯ ТЕСТА =====
 if __name__ == "__main__":
-    print("--- Начинаем тест запроса и форматирования данных из Wikidata ---")
+    logger.info("--- Начинаем тест запроса и форматирования данных из Wikidata ---")
 
     # --- Тест 1: Извлечение и форматирование данных для известного QID ---
     qid_to_test = "Q11660" # Искусственный интеллект
@@ -167,42 +167,42 @@ if __name__ == "__main__":
     """
     actual_query = sparql_template.replace("{QID_PLACEHOLDER}", qid_to_test)
     
-    print(f"\nВыполняем SPARQL-запрос для QID: {qid_to_test}...")
+    logger.info(f"\nВыполняем SPARQL-запрос для QID: {qid_to_test}...")
     results = query_wikidata(actual_query)
 
     if results:
-        print(f"Получено сырых результатов из Wikidata: {len(results)}")
-        print(f"\n--- Форматирование данных для QID: {qid_to_test} ---")
+        logger.info(f"Получено сырых результатов из Wikidata: {len(results)}")
+        logger.info(f"\n--- Форматирование данных для QID: {qid_to_test} ---")
         formatted_texts = format_wikidata_entity_data(qid_to_test, results)
         if formatted_texts:
             for lang_code, text_blob in formatted_texts.items():
-                print(f"\n--- Готовый текст для индексации ({lang_code.upper()}) ---")
-                print(text_blob)
+                logger.info(f"\n--- Готовый текст для индексации ({lang_code.upper()}) ---")
+                logger.info(text_blob)
         else:
-            print("Не удалось сформировать текст из результатов.")
+            logger.warning("Не удалось сформировать текст из результатов.")
     elif isinstance(results, list) and not results: 
-        print(f"Для QID {qid_to_test} не найдено результатов, соответствующих запросу, или произошла ошибка (см. логи выше).")
+        logger.warning(f"Для QID {qid_to_test} не найдено результатов, соответствующих запросу, или произошла ошибка (см. логи выше).")
     
-    print("\n--- Тест 1 завершен ---")
+    logger.info("\n--- Тест 1 завершен ---")
 
     # --- Тест 2: Поиск сущностей по названию с помощью новой функции ---
-    print("\n--- Тест 2: Поиск сущностей по названию ---")
+    logger.info("\n--- Тест 2: Поиск сущностей по названию ---")
     search_term_ru = "Машинное обучение"
-    print(f"\nИщем сущности для: '{search_term_ru}' (язык: ru)")
+    logger.info(f"\nИщем сущности для: '{search_term_ru}' (язык: ru)")
     found_entities_ru = search_wikidata_entities_by_label(search_term_ru, lang="ru", limit=3)
     if found_entities_ru:
         for entity in found_entities_ru:
-            print(f"  QID: {entity.get('qid')}, Метка: {entity.get('label')}, Описание: {entity.get('description')}")
+            logger.info(f"  QID: {entity.get('qid')}, Метка: {entity.get('label')}, Описание: {entity.get('description')}")
     else:
-        print("  Сущности не найдены.")
+        logger.info("  Сущности не найдены.")
 
     search_term_en = "Python programming language"
-    print(f"\nИщем сущности для: '{search_term_en}' (язык: en)")
+    logger.info(f"\nИщем сущности для: '{search_term_en}' (язык: en)")
     found_entities_en = search_wikidata_entities_by_label(search_term_en, lang="en", limit=3)
     if found_entities_en:
         for entity in found_entities_en:
-            print(f"  QID: {entity.get('qid')}, Label: {entity.get('label')}, Description: {entity.get('description')}")
+            logger.info(f"  QID: {entity.get('qid')}, Label: {entity.get('label')}, Description: {entity.get('description')}")
     else:
-        print("  Entities not found.")
+        logger.info("  Entities not found.")
 
-    print("\n--- Тестирование Wikidata Client полностью завершено ---")
+    logger.info("\n--- Тестирование Wikidata Client полностью завершено ---")


### PR DESCRIPTION
## Summary
- add centralized `logging_config` module
- initialize logging across modules using `setup_logging`
- replace leftover `print` statements with `logger` calls

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6860f4879e2083218622fe085bb889ce