### PR TITLE
Add tests for JSON extraction utility

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils import _extract_json_from_response
+
+
+def test_extract_from_json_block():
+    text = "Some text\n```json\n{\"key\": 123}\n```\nMore text"
+    assert _extract_json_from_response(text) == '{"key": 123}'
+
+
+def test_extract_json_with_noise():
+    text = "Noise before {\"a\": 1, \"b\": 2} trailing noise"
+    assert _extract_json_from_response(text) == '{"a": 1, "b": 2}'


### PR DESCRIPTION
## Summary
- add `tests/` directory with `test_utils.py`
- test `_extract_json_from_response` with json code blocks and surrounding noise

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ed9ba3ac832184bbc001b9716481