### PR TITLE
Fix typo in ScenarioObject comment

### DIFF
--- a/ml_nae_core.py
+++ b/ml_nae_core.py
@@ -70,7 +70,7 @@ class ScenarioObject(TypedDict):
     confidence: float             # Уверенность LLM в этом сценарии/действии (0.0-1.0)
     justification: Optional[str]  # Обоснование от LLM
     language: str                 # Язык, на котором сгенерирован сценарий
-    # Дополнительные поля, например, предсказанные последствдия, риски и т.д.
+    # Дополнительные поля, например, предсказанные последствия, риски и т.д.
     predicted_effects_summary: Optional[str]
     estimated_risk_level: Optional[float] # 0.0-1.0
 


### PR DESCRIPTION
## Summary
- fix Russian spelling for "последствия" in `ScenarioObject` description comment

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6860ed92aa608321a4c523f8bd86691e