### PR TITLE
Centralized logging setup

### DIFF
--- a/goal_engine.py
+++ b/goal_engine.py
@@ -5,8 +5,6 @@ from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List
 
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 def form_goal(
     perception_struct: Dict[str, Any], 

--- a/interactive_knowledge_importer.py
+++ b/interactive_knowledge_importer.py
@@ -12,20 +12,12 @@ try:
     from llama_index.core import Document
     modules_loaded = True
 except ImportError as e:
-    logging.basicConfig(level=logging.ERROR) # Установим базовый логгер, если другие не сработали
     logging.error(f"Ошибка импорта необходимых модулей: {e}")
     logging.error("Пожалуйста, убедитесь, что wikidata_client.py и semantic_memory_index.py находятся в той же директории или доступны через PYTHONPATH.")
     modules_loaded = False
 
 # Настройка логгера для этого скрипта
 logger = logging.getLogger(__name__)
-if not logger.handlers and modules_loaded: # Настраиваем, только если основные модули загрузились
-    # Используем существующую конфигурацию логирования, если она была установлена другими модулями,
-    # или устанавливаем свою, если это первый запуск.
-    # Для простоты, предполагаем, что logging.basicConfig уже был вызван в одном из импортируемых модулей.
-    # Если нет, можно добавить здесь:
-    # logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    pass
 
 
 def run_interactive_importer():
@@ -151,8 +143,10 @@ def run_interactive_importer():
             logger.warning(f"Не удалось подготовить документы для индексации для QID {selected_qid}.")
 
 if __name__ == "__main__":
-    # Перед запуском этого скрипта, убедись, что LlamaIndex Settings 
-    # (LLM и EmbedModel) корректно инициализируются при импорте 
+    from utils import setup_logging
+    setup_logging()
+    # Перед запуском этого скрипта, убедись, что LlamaIndex Settings
+    # (LLM и EmbedModel) корректно инициализируются при импорте
     # semantic_memory_index.py (что обычно происходит, если они там в глобальной области видимости).
     # Также убедись, что папка для индекса существует или может быть создана.
     run_interactive_importer()

--- a/mistral_core.py
+++ b/mistral_core.py
@@ -29,8 +29,6 @@ HF_MODEL_NAME: str = "mistralai/Mistral-7B-Instruct-v0.2"
 
 # Настройка логирования
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- Инициализация модели ---
 llm_instance = None
@@ -129,6 +127,8 @@ def query_mistral(
 
 
 if __name__ == '__main__':
+    from utils import setup_logging
+    setup_logging()
     logger.info("--- Тестирование mistral_core.py ---")
     model_ready = False
     if USE_LLAMA_CPP:

--- a/ml_nae_core.py
+++ b/ml_nae_core.py
@@ -13,9 +13,6 @@ import math # Для sigmoid или других функций нормализ
 
 # --- Настройка логгера ---
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- 1. Спецификация интерфейсов и структур данных ---
 
@@ -460,6 +457,8 @@ class SRISNeuroActionEngine:
 
 # --- Пример Моков и Запуска (для иллюстрации) ---
 if __name__ == "__main__":
+    from utils import setup_logging
+    setup_logging()
     # === Mockups ===
     def mock_execute_llm_query_for_sre(prompt: str, mode: str, max_tokens: int, temperature: float) -> str:
         logger.info(f"MOCK SRE LLM Query (mode: {mode}): Промпт получен, начинается с: '{prompt[:150]}...'")

--- a/semantic_memory_fs.py
+++ b/semantic_memory_fs.py
@@ -17,13 +17,8 @@ except OSError as e:
     # Depending on the application's criticality, you might raise the exception
     # or have a fallback mechanism. For now, we'll just log.
 
-# Setup basic logging. In a larger application, logging would be configured globally.
-# Set a more informative format.
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__) # Use __name__ for logger hierarchy
+# Logging configured at application startup
+logger = logging.getLogger(__name__)
 
 # --- Functions ---
 def save_chain_to_fs(chain_data: Dict[str, Any], sub_directory: Optional[str] = None) -> Optional[str]:

--- a/semantic_memory_index.py
+++ b/semantic_memory_index.py
@@ -64,8 +64,6 @@ CORE_SRIS_KNOWLEDGE = [
 ]
 
 logger = logging.getLogger(__name__)
-if not logger.handlers: 
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 try:
     Settings.llm = Ollama(model=OLLAMA_LLM_MODEL_NAME, base_url=OLLAMA_LLM_BASE_URL)
@@ -279,6 +277,8 @@ def query_semantic_memory(index: VectorStoreIndex, query_text: str, similarity_t
 
 # --- Пример использования и тестирования модуля ---
 if __name__ == "__main__":
+    from utils import setup_logging
+    setup_logging()
     logger.info("--- Тестирование модуля semantic_memory_index.py с интеграцией Wikidata и Core Knowledge ---")
     
     FORCE_REBUILD_NOW = True 

--- a/sris_kernel.py
+++ b/sris_kernel.py
@@ -1,5 +1,10 @@
 # sris_kernel.py — Integrated Reasoning Kernel SRIS 1.0 (with Temporality Core & Full GUI code)
 
+import logging
+from utils import setup_logging
+
+setup_logging()
+
 # Стандартные импорты SRIS
 from perception_analysis import analyze_perception
 from sensorium_core import integrate_sensorium
@@ -59,8 +64,6 @@ except ImportError:
 
 # Настройка логирования
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
 # --- Константы и глобальные переменные SRIS ---
 DEFAULT_SDNA = {"adaptivity":0.7,"ethics_sensitivity":0.8,"thinking_style":"deductive","curiosity_level":0.6,"security_priority":0.4,"risk_aversion":0.5,"empathy_level":0.5,"novelty_seeking":0.6,"risk_taking":0.5,"proactiveness":0.5,"efficiency_preference":0.5,"ethical_risk_aversion":0.5,"assertiveness_level":0.5,"transparency_level":0.5}

--- a/sris_server.py
+++ b/sris_server.py
@@ -1,10 +1,13 @@
 # sris_server.py
 import logging
+from utils import setup_logging
 import time
 from fastapi import FastAPI, HTTPException
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field
 from typing import Dict, Any, Optional
+
+setup_logging()
 
 # --- Импорт основных компонентов SRIS ---
 # Убедись, что все эти файлы находятся в той же директории или доступны
@@ -17,14 +20,11 @@ try:
     )
     sris_components_loaded = True
 except ImportError as e:
-    logging.basicConfig(level=logging.ERROR)
     logging.error(f"Критическая ошибка: не удалось импортировать компоненты SRIS. {e}")
     sris_components_loaded = False
 
 # --- Настройка логирования ---
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 # --- Модели данных для API ---
 class QueryRequest(BaseModel):

--- a/temporality_core.py
+++ b/temporality_core.py
@@ -5,8 +5,6 @@ from datetime import datetime, timezone # <--- ВОТ ЭТА СТРОКА ДОБ
 
 # Настройка логгера для этого модуля
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    pass # Предполагаем, что логирование настроено в sris_kernel.py
 
 class TimeSense:
     # ... (остальной код класса TimeSense без изменений) ...

--- a/utils.py
+++ b/utils.py
@@ -4,6 +4,21 @@ import json
 import re
 from typing import Dict, Any, Optional, Union
 
+DEFAULT_LOG_FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+
+def setup_logging(level: int = logging.INFO, fmt: str = DEFAULT_LOG_FORMAT) -> None:
+    """Configure root logging for the application.
+
+    This should be called once at application startup.
+    If handlers already exist, only the level will be updated.
+    """
+    root_logger = logging.getLogger()
+    if not root_logger.handlers:
+        logging.basicConfig(level=level, format=fmt)
+    else:
+        root_logger.setLevel(level)
+    logging.getLogger(__name__).debug("Logging configured")
+
 try:
     from mistral_core import query_mistral
     mistral_core_available = True

--- a/wikidata_client.py
+++ b/wikidata_client.py
@@ -6,9 +6,6 @@ from typing import List, Dict, Optional, Any # Добавил Any
 
 # Настройка логгера
 logger = logging.getLogger(__name__)
-if not logger.handlers:
-    logging.basicConfig(level=logging.INFO,
-                        format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 WIKIDATA_SPARQL_ENDPOINT = "https://query.wikidata.org/sparql"
 WIKIDATA_API_ENDPOINT = "https://www.wikidata.org/w/api.php" # Эндпоинт для wbsearchentities
@@ -143,6 +140,8 @@ def format_wikidata_entity_data(qid: str, sparql_results: List[Dict[str, str]]) 
 
 # ===== БЛОК ДЛЯ ТЕСТА =====
 if __name__ == "__main__":
+    from utils import setup_logging
+    setup_logging()
     print("--- Начинаем тест запроса и форматирования данных из Wikidata ---")
 
     # --- Тест 1: Извлечение и форматирование данных для известного QID ---


### PR DESCRIPTION
## Summary
- add `setup_logging` helper in `utils.py`
- configure logging once in `sris_kernel.py` and `sris_server.py`
- remove per-module `logging.basicConfig` calls
- initialize logging when running individual test scripts

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860eb4995948321b2cb0e116cddb4bf